### PR TITLE
Fix audit issues #4-#17 across nginx, terminal, and routes

### DIFF
--- a/backend/session.js
+++ b/backend/session.js
@@ -561,7 +561,7 @@ class SessionManager {
     if (command === 'welcome') {
       try { session.socket.emit('tti', { phase: 'welcome-start' }); } catch { /* ignore */ }
       const chars = [...command];
-      const perCharMs = 55;
+      const perCharMs = 20;
       chars.forEach((ch, i) => {
         setTimeout(() => {
           if (this.sessions.has(sessionId)) this.sendInput(sessionId, ch);

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -196,10 +196,10 @@ RUN cp /home/portfolio/.dotfiles/zsh/zshrc /home/portfolio/.zshrc && \
     echo "alias dotfiles='cd ~/.dotfiles && /home/portfolio/scripts/dotfiles.sh'" >> /home/portfolio/.zshrc && \
     echo "alias home='cd ~ && /home/portfolio/scripts/welcome.sh'" >> /home/portfolio/.zshrc && \
     echo "alias welcome='cd ~ && /home/portfolio/scripts/welcome.sh'" >> /home/portfolio/.zshrc && \
-    echo "alias contact='/home/portfolio/scripts/contact.sh'" >> /home/portfolio/.zshrc && \
-    echo "alias about='/home/portfolio/scripts/about.sh'" >> /home/portfolio/.zshrc && \
+    echo "alias contact='cd ~ && /home/portfolio/scripts/contact.sh'" >> /home/portfolio/.zshrc && \
+    echo "alias about='cd ~ && /home/portfolio/scripts/about.sh'" >> /home/portfolio/.zshrc && \
     echo "alias help='/home/portfolio/scripts/help.sh'" >> /home/portfolio/.zshrc && \
-    echo "alias resume='/home/portfolio/scripts/resume.sh'" >> /home/portfolio/.zshrc && \
+    echo "alias resume='cd ~ && /home/portfolio/scripts/resume.sh'" >> /home/portfolio/.zshrc && \
     echo "alias blog='/home/portfolio/scripts/blog.sh'" >> /home/portfolio/.zshrc && \
     echo "" >> /home/portfolio/.zshrc && \
     echo "# preexec — re-emit OSC 9999 URL before every typed command so the" >> /home/portfolio/.zshrc && \
@@ -288,10 +288,10 @@ RUN echo 'export PATH="/home/portfolio/scripts:$PATH"' >> /home/portfolio/.bashr
     echo "alias dotfiles='cd ~/.dotfiles && /home/portfolio/scripts/dotfiles.sh'" >> /home/portfolio/.bashrc && \
     echo "alias home='cd ~ && /home/portfolio/scripts/welcome.sh'" >> /home/portfolio/.bashrc && \
     echo "alias welcome='cd ~ && /home/portfolio/scripts/welcome.sh'" >> /home/portfolio/.bashrc && \
-    echo "alias contact='/home/portfolio/scripts/contact.sh'" >> /home/portfolio/.bashrc && \
-    echo "alias about='/home/portfolio/scripts/about.sh'" >> /home/portfolio/.bashrc && \
+    echo "alias contact='cd ~ && /home/portfolio/scripts/contact.sh'" >> /home/portfolio/.bashrc && \
+    echo "alias about='cd ~ && /home/portfolio/scripts/about.sh'" >> /home/portfolio/.bashrc && \
     echo "alias help='/home/portfolio/scripts/help.sh'" >> /home/portfolio/.bashrc && \
-    echo "alias resume='/home/portfolio/scripts/resume.sh'" >> /home/portfolio/.bashrc
+    echo "alias resume='cd ~ && /home/portfolio/scripts/resume.sh'" >> /home/portfolio/.bashrc
 
 # Set proper ownership
 RUN chown -R portfolio:portfolio /home/portfolio

--- a/container/scripts/about.sh
+++ b/container/scripts/about.sh
@@ -3,12 +3,12 @@ source "$(dirname "$0")/shared-functions.sh"
 emit_url "about"
 
 echo ""
-create_box "About Me" "Hi, I'm Tim. I'm 19 and from San Francisco, CA, and
-Currently, I'm a Web Programming and Design student at Purdue University
-and am working on tradeupbot.app (check it out!)
+create_box "About Me" "Hi, I'm Tim. I'm based in San Francisco, CA, and I work on AI agent tooling.
+Recent projects include agentelo (a multi-model agent leaderboard), hone
+(prompt-honing harness), and harness/harness-bench (agent benchmarking).
 
-In my spare time I like to make side projects, like the one you're reading.
+In my spare time I tinker with side projects like the one you're reading.
 
-type contact to see my contact info
-type projects to see my projects" "$PURPLE" 80
+type projects to see what I'm working on
+type contact to get in touch" "$PURPLE" 80
 echo ""

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/addon-web-links": "^0.11.0",
+        "@xterm/addon-webgl": "^0.18.0",
         "@xterm/xterm": "^5.5.0",
         "next": "^15.5.15",
         "react": "19.1.4",
@@ -1958,6 +1959,15 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-web-links/-/addon-web-links-0.11.0.tgz",
       "integrity": "sha512-nIHQ38pQI+a5kXnRaTgwqSHnX7KE6+4SVoceompgHL26unAxdfP6IPqUTSYPQgSwM56hsElfoNrrW5V7BUED/Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@xterm/xterm": "^5.0.0"
+      }
+    },
+    "node_modules/@xterm/addon-webgl": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-webgl/-/addon-webgl-0.18.0.tgz",
+      "integrity": "sha512-xCnfMBTI+/HKPdRnSOHaJDRqEpq2Ugy8LEj9GiY4J3zJObo3joylIFaMvzBwbYRg8zLtkO0KQaStCeSfoaI2/w==",
       "license": "MIT",
       "peerDependencies": {
         "@xterm/xterm": "^5.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-web-links": "^0.11.0",
+    "@xterm/addon-webgl": "^0.18.0",
     "@xterm/xterm": "^5.5.0",
     "next": "^15.5.15",
     "react": "19.1.4",

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -9,6 +9,7 @@ import {
 import { Terminal as XTermTerminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
+import { WebglAddon } from "@xterm/addon-webgl";
 import { terminalConfig } from "../config/terminal-theme";
 import { attachTouchScroll } from "../lib/xterm-touch";
 
@@ -80,7 +81,6 @@ const Terminal = forwardRef<TerminalRef, TerminalProps>(
       const handleLinkActivate = (_event: MouseEvent, text: string) => {
         window.open(text, "_blank", "noopener,noreferrer");
       };
-      xterm.loadAddon(new WebLinksAddon(handleLinkActivate));
       xterm.options.linkHandler = {
         activate: handleLinkActivate,
         allowNonHttpProtocols: true,
@@ -89,6 +89,12 @@ const Terminal = forwardRef<TerminalRef, TerminalProps>(
       xterm.open(terminalRef.current);
       xtermRef.current = xterm;
       fitAddonRef.current = fitAddon;
+
+      try {
+        const webgl = new WebglAddon();
+        webgl.onContextLoss(() => webgl.dispose());
+        xterm.loadAddon(webgl);
+      } catch { /* fall back to canvas */ }
 
       const oscUrlDisposable = xterm.parser.registerOscHandler(9999, (data) => {
         try {
@@ -164,6 +170,9 @@ const Terminal = forwardRef<TerminalRef, TerminalProps>(
       const currentTerminalElement = terminalRef.current;
       currentTerminalElement.addEventListener("click", handleClick);
 
+      const loadWebLinks = () => xterm.loadAddon(new WebLinksAddon(handleLinkActivate));
+      currentTerminalElement.addEventListener("mouseover", loadWebLinks, { once: true });
+
       const detachTouch = attachTouchScroll(xterm, currentTerminalElement);
 
       const handlePaste = async (event: ClipboardEvent) => {
@@ -235,6 +244,8 @@ const Terminal = forwardRef<TerminalRef, TerminalProps>(
         },
         () =>
           currentTerminalElement.removeEventListener("click", handleClick),
+        () =>
+          currentTerminalElement.removeEventListener("mouseover", loadWebLinks),
         () =>
           currentTerminalElement.removeEventListener("paste", handlePaste),
         () =>

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -13,8 +13,9 @@ import { terminalConfig } from "../config/terminal-theme";
 import { attachTouchScroll } from "../lib/xterm-touch";
 
 const MOBILE_BREAKPOINT = 768;
-const MIN_FONT_SIZE = 13;
+const MIN_FONT_SIZE = 10;
 const MAX_FONT_SIZE = 28;
+const CHAR_WIDTH_RATIO = 0.6;
 
 // Pick font size directly from viewport width. Cols fall out via xterm's
 // FitAddon so box widths, figlet output, etc. scale naturally — narrow
@@ -22,11 +23,14 @@ const MAX_FONT_SIZE = 28;
 // readable font instead of wasting real estate on 200+ cols.
 function calculateFontSize(_container: HTMLElement): number {
   const viewportWidth = window.innerWidth;
-  // Mobile gets a fixed small font; desktop scales ~1px per 80px of viewport.
-  const target = viewportWidth < MOBILE_BREAKPOINT
-    ? 13
-    : Math.round(viewportWidth / 80);
-  return Math.max(MIN_FONT_SIZE, Math.min(MAX_FONT_SIZE, target));
+  if (viewportWidth < MOBILE_BREAKPOINT) {
+    // Derive target cols from actual usable width so we never exceed what
+    // the viewport can display at the minimum font size.
+    const usableWidth = viewportWidth - 28; // 14px padding each side
+    const targetCols = Math.max(40, Math.min(80, Math.floor(usableWidth / (MIN_FONT_SIZE * CHAR_WIDTH_RATIO))));
+    return Math.max(MIN_FONT_SIZE, Math.min(MAX_FONT_SIZE, Math.floor(usableWidth / (targetCols * CHAR_WIDTH_RATIO))));
+  }
+  return Math.max(MIN_FONT_SIZE, Math.min(MAX_FONT_SIZE, Math.round(viewportWidth / 80)));
 }
 
 interface TerminalProps {


### PR DESCRIPTION
## Summary
This PR implements the bugbash plan for audit issues #4 through #17 with one focused fix per issue, prioritized P0→P3 and merged via integration.

## What was planned (architect)
- Enumerate open issues and execute minimal, targeted fixes for each.
- Keep patches scoped, test each area reasonably, and avoid unrelated refactors.
- Bundle all node deliveries into one integration PR.

## Node deliveries

### `twaldin` (issues #9, #10)
- Updated `container/scripts/about.sh` copy to current bio/project text (#9).
- Fixed shell aliases in `container/Dockerfile` (`resume`, `about`, `contact`) to `cd ~` before script execution, preventing wrong-CWD behavior (#10).
- Verified welcome scripts do not move users into `~/projects`.

### `execute-metadata-routes-nav-coder` (issues #7, #8, #11, #12)
- Implemented proper unknown-route handling with `notFound()` and terminal-backed `not-found.tsx` (#7).
- Added per-route metadata generation and layout title template/default (#8).
- Added OpenGraph + Twitter metadata in layout and route-level OG URL/title support (#11).
- Added `about` and `contact` links in header nav (#12).
- Build verification passed.

### `execute-terminal-perf-coder` (issues #6, #13, #16)
- Improved mobile terminal fit by adjusting font sizing/char width assumptions for better column count on small screens (#6).
- Reduced terminal time-to-interactive dead time by accelerating backend welcome auto-type timing (#13).
- Added xterm WebGL addon with safe fallback and deferred WebLinks addon initialization (#16).
- Syntax/build checks passed.

### `execute-nginx-perf-coder` (issues #4, #15, #17)
- Split nginx rate limiting to isolate `/agentelo` traffic into its own higher-capacity zone while retaining global limits elsewhere (#4).
- Enabled Brotli via brotli-capable nginx image and compression directives (#15).
- Added proxy cache policy for HTML catch-all route with stale-serve/lock behavior and cache-status response header (#17).
- Docker daemon was unavailable locally for `nginx -t`; config reviewed and CI/runtime validation recommended.

## Notes for reviewers
- A few implementations intentionally use explicit command allowlists in route metadata/404 handling; update those lists when adding new terminal commands.
- OG/Twitter metadata currently text-only (no stable OG image asset was available).
