### PR TITLE
fix(mobile): proper line-stepped terminal scroll + kill blog rubber-band

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -31,6 +31,16 @@ html, body {
   height: 100%;
 }
 
+/* Block rubber-band overscroll on mobile so users can't drag past the top
+   or bottom of the document and see the white "void" outside <html>. iOS
+   Safari and Android Chrome both honor overscroll-behavior-y: none on the
+   root. The terminal page is height: 100vh so it can't overscroll anyway,
+   but blog/static pages can — without this, scrolling past the end of the
+   article shows a white area underneath. */
+html {
+  overscroll-behavior-y: none;
+}
+
 body {
   display: flex;
   flex-direction: column;

--- a/frontend/src/lib/xterm-touch.ts
+++ b/frontend/src/lib/xterm-touch.ts
@@ -2,9 +2,22 @@
 //
 // xterm renders into a canvas, so the browser has no native overflow scroll
 // to apply to touch drags — users get single-line stutter scrolling or
-// nothing at all. This attaches a custom touch handler with 1:1 finger-to-
-// scroll mapping plus momentum-decay on touch end. Taps (no drag) pass
-// through untouched so xterm.focus()/keyboard-open still work.
+// nothing at all. This attaches a custom touch handler with finger-to-line
+// mapping plus momentum-decay on touch end. Taps (no drag) pass through
+// untouched so xterm.focus()/keyboard-open still work.
+//
+// Why scrollLines() instead of vp.scrollTop:
+//   The previous implementation drove `vp.scrollTop` directly in pixels,
+//   relying on xterm's scroll listener to reconcile the canvas. In practice
+//   the canvas/WebGL renderer doesn't always repaint on sub-line scrollTop
+//   changes — pixel-level mutations would accumulate without visible
+//   movement, then the canvas would snap multiple lines on the next
+//   rerender threshold. Result: thumb drags produced jumpy, decoupled
+//   content scroll. xterm.scrollLines(N) forces a renderer repaint at line
+//   boundaries, which is the smallest unit the renderer actually honors.
+//   We accumulate sub-line pixel movement and emit scrollLines only when
+//   we cross a row-height boundary, so 1px finger ≈ 1 row scroll on a
+//   16px row is correct (and the cumulative position tracks the thumb).
 //
 // Usage:
 //   const detach = attachTouchScroll(xterm, hostElement);
@@ -17,9 +30,9 @@ const DRAG_THRESHOLD_PX = 6;        // finger must move this far before we claim
 const MOMENTUM_DECAY = 0.95;        // per-frame velocity multiplier (higher = longer glide)
 const MOMENTUM_MIN_VELOCITY = 0.2;  // px/ms — even a gentle lift gets a small glide
 const MOMENTUM_STOP = 0.04;         // px/ms below which the momentum loop exits
+const FALLBACK_ROW_HEIGHT_PX = 16;  // used only if we can't measure live
 
 export function attachTouchScroll(xterm: Terminal, host: HTMLElement): () => void {
-  void xterm;
   const getViewport = (): HTMLElement | null =>
     host.querySelector<HTMLElement>(".xterm-viewport");
 
@@ -29,6 +42,7 @@ export function attachTouchScroll(xterm: Terminal, host: HTMLElement): () => voi
   let velocity = 0;        // px / ms, positive = finger moving UP (content scrolls DOWN)
   let isDragging = false;
   let momentumRaf: number | null = null;
+  let accumPx = 0;          // sub-line pixel remainder; flushed when |accumPx| >= rowHeight
   let origHostTouchAction = "";
   let origViewportTouchAction = "";
 
@@ -39,14 +53,28 @@ export function attachTouchScroll(xterm: Terminal, host: HTMLElement): () => voi
     }
   };
 
-  // Drive xterm's own viewport.scrollTop directly so the finger-to-content
-  // ratio is a clean 1:1 in pixels — xterm has a scroll listener that
-  // reconciles the canvas to wherever scrollTop lands.
-  const scrollByPixels = (px: number): void => {
+  // Estimate the row height in CSS pixels by dividing the viewport's visible
+  // height by xterm's row count. Falls back to a static value if the viewport
+  // hasn't been measured yet (early touchstart before xterm.open finishes).
+  const rowHeightPx = (): number => {
     const vp = getViewport();
-    if (!vp) return;
-    const next = Math.max(0, Math.min(vp.scrollHeight - vp.clientHeight, vp.scrollTop + px));
-    vp.scrollTop = next;
+    const rows = (xterm as Terminal & { rows?: number }).rows;
+    if (!vp || !rows || rows <= 0) return FALLBACK_ROW_HEIGHT_PX;
+    const measured = vp.clientHeight / rows;
+    return measured > 0 ? measured : FALLBACK_ROW_HEIGHT_PX;
+  };
+
+  // Convert finger pixel delta into integer line scrolls via xterm's own
+  // scroll API, which the renderer always honors with a repaint. Sub-line
+  // remainder accumulates so a slow drag doesn't get rounded away.
+  const scrollByPixels = (px: number): void => {
+    accumPx += px;
+    const h = rowHeightPx();
+    const lines = Math.trunc(accumPx / h);
+    if (lines !== 0) {
+      try { xterm.scrollLines(lines); } catch { /* alt-screen / disposed */ }
+      accumPx -= lines * h;
+    }
   };
 
   const onTouchStart = (e: TouchEvent): void => {
@@ -57,6 +85,7 @@ export function attachTouchScroll(xterm: Terminal, host: HTMLElement): () => voi
     lastMoveTime = performance.now();
     velocity = 0;
     isDragging = false;
+    accumPx = 0;  // start a fresh fractional accumulator each gesture
   };
 
   const onTouchMove = (e: TouchEvent): void => {


### PR DESCRIPTION
## Bug 1: terminal scroll on mobile felt jumpy/decoupled

The touch handler was driving `vp.scrollTop` in pixels directly, expecting xterm's scroll listener to reconcile the canvas/WebGL renderer. In practice the renderer doesn't repaint on sub-line `scrollTop` changes — pixel mutations accumulated invisibly and the canvas snapped multiple lines at unpredictable thresholds. Result: thumb travel didn't translate to visible content movement.

**Fix**: switch to `xterm.scrollLines(N)` with a sub-line pixel accumulator (`accumPx`). Every cumulative finger px ≥ row-height triggers a one-line scroll, fractional remainder carries to the next `touchmove`. The renderer repaints on every emitted scroll, content tracks the thumb predictably. Same pattern in the momentum frame loop, so the post-lift glide is smooth too.

## Bug 2: blog / static pages had white void on overscroll

iOS Safari (and Android Chrome) rubber-band scrolling let users drag past the top/bottom of the article body and see white area outside `<html>`.

**Fix**: `overscroll-behavior-y: none` on `html` in `globals.css`. Kills the rubber-band on both browsers. The terminal page is `height: 100vh` so it can't overscroll anyway; this only changes blog/static behavior.

## Verified

- `pnpm build` green
- `pnpm test` 21/21 pass
- Manual mobile test deferred to deploy (no easy device sim for xterm WebGL touch behavior)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the white void "rubber-band" overscroll bounce effect on iOS Safari and Android Chrome that appeared when scrolling past the top or bottom of content on mobile browsers.
  * Improved touch scrolling precision and responsiveness for terminal interactions with enhanced sub-line accuracy, better handling of fractional pixel scrolling between touch movements, and refined momentum behavior that more accurately responds to gesture transitions while maintaining smooth performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->