### PR TITLE
fix(mobile): bottom dead-zone on terminal so cursor stays above thumb area

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -41,6 +41,18 @@ html {
   overscroll-behavior-y: none;
 }
 
+/* Mobile-only bottom padding on the terminal host so the cursor + last
+   output line don't pin to the literal bottom of the screen — phones have
+   a hard-to-read lower zone (iOS URL bar / home indicator / awkward thumb
+   reach). The padding shrinks xterm's inner content area; FitAddon sizes
+   rows from that, so the grid is honored. The padded space is just the
+   terminal background color. */
+@media (max-width: 767px) {
+  .terminal-host {
+    padding-bottom: 25vh !important;
+  }
+}
+
 body {
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -310,10 +310,16 @@ const Terminal = forwardRef<TerminalRef, TerminalProps>(
 
     return (
       <div
+        className="terminal-host"
         style={{
           width: "100%",
           height: "100%",
           margin: 0,
+          // padding-bottom is overridden to ~25vh on mobile via globals.css —
+          // gives the cursor + last output line breathing room above the
+          // hard-to-read lower thumb zone of phones (where iOS URL bar +
+          // home indicator land). FitAddon sizes rows from the inner
+          // content area, so xterm's grid honors the reduced height.
           padding: "6px 14px",
           boxSizing: "border-box",
           backgroundColor: terminalConfig.theme.background,


### PR DESCRIPTION
User report: '*on mobile, the bottom half of the screen is kinda unreadable but we don't allow overscroll*' — the cursor + last output line pinned to the literal bottom of the viewport, where iOS URL bar / home indicator / awkward thumb reach combine to make text hard to read.

## Fix

`25vh` bottom padding on the terminal host (`.terminal-host` class) on mobile only, via media query in `globals.css`. xterm's FitAddon sizes rows from the inner content area so the grid honors the reduced height; the padded zone is just terminal bg, no canvas there.

Net: on phones, the last ~25% of the screen below the cursor is empty bg color. Cursor + last output sit higher up, in the thumb-readable zone. Desktop unchanged.

## Verified

- `pnpm build` green