### PR TITLE
docs: refresh CLAUDE.md (root + frontend/backend/container nested)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,9 +54,6 @@ build/
 mobile-blog-*.png
 state.md
 
-# flt agent files (generated per machine)
-CLAUDE.md
-
 # dev symlink to container/blog/posts for Next.js
 frontend/blog-posts
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,130 @@
+# tim.waldin.net (term-site)
+
+Interactive terminal-themed portfolio at [tim.waldin.net](https://tim.waldin.net). Visitors land on a web-based xterm.js terminal that connects via Socket.IO to a Node.js backend, which leases them an isolated Ubuntu Docker container running a custom zsh shell with portfolio scripts (figlet ASCII art, project pages, blog, resume).
+
+## Three layers
+
+```
+Browser                Server                       Sandbox
+─────────────          ──────────────               ─────────────────
+Next.js 15 +    ──→    Nginx (TLS, rate-limit) ──→  Docker container
+xterm.js 5.5    ←──    Express + Socket.IO     ←──  per visitor IP
+                       dockerode → socket-proxy     (zsh + scripts)
+```
+
+- **`frontend/`** — Next.js 15 / React 19 app. Renders xterm.js with Gruvbox Dark + JetBrainsMono Nerd Font, a Socket.IO client, and a URL ↔ command sync layer (typing `projects` updates the URL to `/projects/...`; visiting `/blog/<slug>` auto-types `blog <slug>`). See `frontend/CLAUDE.md`.
+- **`backend/`** — Node.js + Express + Socket.IO + dockerode. Manages a pre-warmed pool of containers, leases one per visitor IP, handles input/output streaming, resize, idle/no-input timeouts, zombie-reconnect, and admin auth. See `backend/CLAUDE.md`.
+- **`container/`** — Ubuntu 24.04 image (`twaldin/terminal-portfolio:latest`) with zsh, Oh My Posh, neovim (nightly via bob), figlet/mdcat/glow, and `scripts/*.sh` for the portfolio (welcome, projects, blog, resume, contact, etc.). See `container/CLAUDE.md`.
+
+## Runtime model: pre-warmed pool + IP-pinned sessions
+
+The backend keeps **5 warm containers** ready (`SessionManager.poolSize`, `backend/session.js:31`) so new connections skip the 1–2s `createContainer` latency. Hard cap of **40 concurrent sessions** (`maxSessions`, `backend/session.js:17`).
+
+Each visitor IP holds **one live session at a time**. A new Socket.IO connection from the same IP immediately closes the old one — see `ipSessions` map in `backend/server.js:54` and the kick logic in `backend/server.js:116-131`. Concretely:
+
+- Open a second tab from the same IP → the old tab's session is collapsed into the new tab (old socket gets `[replaced by a new session from this ip]` and disconnects). The container is reused only when the new tab presents the same `localStorage` `sessionId` (persistent-session restore, `backend/session.js:677`); otherwise the old container is destroyed and a fresh one is leased.
+- Refresh the same tab → the persistent `sessionId` is sent in the Socket.IO handshake auth, the existing container is reattached, the URL's `initCommand` is re-run so the visible output repaints. Backend rule of thumb: *one IP = one slot*.
+- Type `exit` → container is killed, slot is freed.
+
+Disconnect without `exit` (browser close, network drop) → session is **zombified** with a 30s grace window (`zombifySession`, `backend/session.js:871`) so a quick reconnect from the same IP/sessionId can reattach without losing shell state.
+
+Idle / bot timers, all in `backend/session.js`:
+
+- **5 min idle** without keystrokes → kill (`sessionTimeout`, line 21).
+- **60 s no-input** from connect → kill (`noInputTimeout`, line 24) — kills bots and background tabs that never engage.
+- **30 connection attempts/min per IP** rate-limit at the Socket.IO layer (`backend/server.js:47`).
+
+## Sandbox / security
+
+- Each session container runs as non-root `portfolio` user with `CapDrop: ALL` (only `SETUID/SETGID` re-added for sudo demo), `NetworkMode: none`, `PidsLimit: 100`, 512 MB RAM, 0.5 CPU, `tmpfs /tmp` (noexec, nosuid). Spec: `backend/session.js:46`. Visitors can run `sudo rm -rf /` or fork-bombs — only their own container is affected, never the host.
+- `tecnativa/docker-socket-proxy` exposes the Docker API to the backend over `tcp://socket-proxy:2375` with a strict allowlist: `CONTAINERS=1, IMAGES=1, POST=1` and everything else (`NETWORKS, VOLUMES, BUILD, EXEC, SERVICES, SWARM`) disabled. The backend never gets a raw `/var/run/docker.sock`. See `docker-compose.yml:40-62`.
+
+## Deployment shape
+
+`docker-compose.yml` brings up four services on three internal Docker networks plus one external bridge:
+
+| Service        | Image / build                          | Network                     |
+|----------------|----------------------------------------|-----------------------------|
+| `nginx`        | `nginx:alpine` + `nginx.conf`          | external + frontend + backend |
+| `frontend`     | `frontend/Dockerfile.production`        | frontend (internal)         |
+| `backend`      | `backend/Dockerfile`                    | backend + docker (internal) |
+| `socket-proxy` | `tecnativa/docker-socket-proxy`         | docker (internal)           |
+
+Nginx terminates TLS via Let's Encrypt (`/etc/letsencrypt` mounted read-only), enforces global rate limits (10 r/s, burst 20), proxies `/socket.io/` with WebSocket upgrade, caches `/fonts/` aggressively, and blocks the Next.js CVE-2025-29927 middleware-bypass header. Session containers themselves are spawned dynamically by the backend on the host's default bridge — they're not declared in compose.
+
+`deploy.sh` is the production deploy entry point.
+
+## Local dev
+
+- `cd frontend && pnpm dev` (Next 15 with Turbopack, port 3000).
+- `cd backend && npm start` (port 3001; needs `DOCKER_HOST` or a local docker socket).
+- For a full local stack: `docker compose -f docker-compose.local.yml up`.
+- The container image is built with `container/build.sh` → tags `twaldin/terminal-portfolio:latest`. The backend looks up the image by exact tag in `backend/session.js:240` and warns if it's missing locally.
+
+## Pointers
+
+- **`frontend/CLAUDE.md`** — Terminal component, dynamic font sizing, OSC 8 / OSC 9999 URL sync, Socket.IO handshake, blog static pages.
+- **`backend/CLAUDE.md`** — Session lifecycle, pool warming, IP-pinned session + tab-collapse, zombie reconnect, admin panel.
+- **`container/CLAUDE.md`** — Dockerfile shape, portfolio scripts, Oh My Posh prompt, baked-in nvim plugins, OSC URL emit hook in zshrc.
+
+## Conventions
+
+- Every directory with a `CLAUDE.md` also has an `AGENTS.md` symlink → `CLAUDE.md`. Treat `CLAUDE.md` as canonical; edit only `CLAUDE.md`, never `AGENTS.md`.
+- Diagnosis scratch files at the repo root (`MOBILE-RENDER-DIAGNOSIS.md`, `TTI-DIAGNOSIS.md`) are historical investigation notes, not authoritative docs.
+
+<!-- flt:start -->
+# Fleet Agent: writer-term
+You are a managed subagent in a fleet orchestrated by flt.
+Parent agent: project-convs-grill | CLI: claude-code | Model: opus[1m]
+
+## communication
+- Parent is another agent. Send progress/questions via `flt send parent "..."`.
+- Use parent as the primary coordination channel.
+- `flt send parent "..."` — in-scope status, blockers, completion. Default channel.
+- `flt ask oracle "<question>" --from writer-term` — out-of-scope research, second opinions, ambiguous design choices. Reply lands in your inbox, not the human's.
+- Do NOT message the human directly. Parent or oracle, never human.
+
+## flt quick commands
+- send message: `flt send <agent|parent> "message"`
+- ask oracle: `flt ask oracle "<question>" --from writer-term`
+- list agents: `flt list`
+- view logs: `flt logs <name>`
+
+## handoffs
+- If you produce a candidate output (summary, plan, diff, eval), write it to `$FLT_RUN_DIR/handoffs/<your-name>.md` when `$FLT_RUN_DIR` is set. `collect_artifacts` steps preserve this file across worktree teardown.
+
+## skills
+- No skills loaded for this run. Skills are opt-in at spawn.
+
+## protocol
+- Report completion and blockers quickly.
+- Do not modify this flt instruction block.
+
+
+# Architect
+
+Take a spec and produce an implementation plan. You don't code — you design. Your job is to make the coder's job mechanical.
+
+## Responsibilities
+
+Read `$FLT_RUN_DIR/artifacts/spec.md` and `acceptance.md`, then inspect the existing repo (file structure, naming patterns, current tests, existing utilities to reuse). Produce in `$FLT_RUN_DIR/artifacts/`:
+
+- `design.md` — implementation approach, key types/interfaces, control flow, fallback behavior. Reference existing code by `path:line` when reusing.
+- `files_to_touch.md` — bullet list of every file likely to be created/modified. Mark "create" vs "modify".
+- `test_plan.md` — which tests to write/update and at which boundary (unit/integration/e2e).
+- `risk_register.md` — non-obvious failure modes, race conditions, security-sensitive paths, scope creep risks.
+
+## Comms
+
+- Parent receives `flt send parent "design done: <files-touched-count>, <risks-flagged-count>"`.
+- For library/API choices you're uncertain about, `flt ask oracle '<question>'` first.
+- Never message the human directly.
+
+## Guardrails
+
+- Inspect actual code before designing. Grep the repo. Read existing files. Do not design against assumed structure.
+- Prefer reusing existing utilities over inventing new abstractions.
+- No premature abstraction. Three similar lines is fine; a generalized helper for two callers is not.
+- If the spec is contradictory or impossible against the existing repo, raise it as a blocker via `flt send parent "blocked: <reason>"` and stop.
+
+<!-- flt:end -->

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -1,0 +1,59 @@
+# backend/
+
+Node.js 18 + Express + Socket.IO server (`server.js`) and a `SessionManager` (`session.js`) that wraps `dockerode` to manage per-visitor Ubuntu containers. Talks to the Docker API through `tecnativa/docker-socket-proxy` over `tcp://socket-proxy:2375` — never to a raw `/var/run/docker.sock`.
+
+## Files
+
+- **`server.js`** — Express app, Socket.IO server, CORS allowlist, per-IP rate limit, IP→sessionId map, command-buffer audit logger, graceful shutdown.
+- **`session.js`** — `SessionManager` class. Container pool, lease/attach, persistent-session reattach, zombie/grace, idle timers, orphan cleanup, image preload.
+- **`admin.js`** — basic-auth-protected `/admin` router (`ADMIN_EMAIL` / `ADMIN_PASSWORD` from env, surfaces session/log views).
+- **`logger.js`** — JSONL audit log to `backend_data` volume (`session_start`, `session_end`, `command` events).
+
+## Runtime model: pre-warmed pool, IP-pinned sessions
+
+- **Pool**: 5 warm containers kept ready (`poolSize`, `session.js:31`). On lease, the pool is replenished in the background. Pool warm-up runs `welcome` once during build to populate the figlet/OMP cache so the first visitor sees instant output.
+- **Hard cap**: 40 concurrent sessions (`maxSessions`, `session.js:17`). Beyond that, `createSession` throws and the client gets `error: 'Failed to create terminal session'`.
+- **Single session per IP**: `ipSessions: Map<ip, socketId>` in `server.js:54`. A new connection from an IP that already has a session sends `[replaced by a new session from this ip]` to the old socket, disconnects it, destroys the old session, then takes the slot (`server.js:116-131`).
+- **Persistent sessionId path**: if the client's handshake auth includes a `sessionId` (UUID stored client-side in `localStorage`), `restoreByPersistentSessionId` (`session.js:677`) reattaches the existing container instead of creating a new one. If the existing session is on a different socket, the old socket gets `[session continued in a new tab]` and is disconnected — the container itself is reused (`server.js:99-110`). Refresh in the same tab takes this path.
+- **Zombie reconnect**: on socket disconnect (browser close, network blip), `zombifySession` (`session.js:871`) keeps the container alive in `zombieSessions: Map<ip, {session, graceTimer}>` for **30 seconds**. A reconnect from the same IP within that window reattaches via `tryReattach` (`session.js:827`). After 30s the grace timer fires and the container is killed.
+
+## Idle / bot timers (`session.js`)
+
+| Timer                     | Field             | Reset on              | Action |
+|---------------------------|-------------------|-----------------------|--------|
+| `sessionTimeout` (5 min)  | `session.timeout` | `sendInput`           | kill session, emit `[session idle — closed]` |
+| `noInputTimeout` (60 s)   | `session.noInputTimer` | first `sendInput` (cancels) | kill session if no keystrokes ever arrived |
+| Connection rate limit     | `connectionTracker` | sliding 60 s window | reject if >30 connects/min from one IP (`server.js:47`) |
+
+Resize is a passive signal — it does **not** reset `sessionTimeout` (`session.js:608` comment).
+
+## Container spec (`session.js:46`)
+
+`twaldin/terminal-portfolio:latest`, non-root `portfolio` user, `NetworkMode: none`, `CapDrop: ALL` plus `CapAdd: SETUID, SETGID` (so the container's `sudo` demo works), 512 MB RAM, 0.5 CPU, `PidsLimit: 100`, `tmpfs /tmp` (rw, noexec, nosuid, 100m). `LANG=C.UTF-8 / LC_ALL=C.UTF-8` so multi-byte glyphs render in `less` / `cat`.
+
+`COLUMNS` / `LINES` are deliberately **not** set in `Env`. Scripts that read them at startup would render at 80×24 until the first client resize lands; instead we gate `initCommand` on both `promptSeen` and `firstResizeApplied` (`maybeRunInitCommand`, `session.js:654`) so figlet/nvim/blog never render at the wrong size.
+
+## Boot sequence for a new visitor
+
+1. Socket connects with optional `auth.sessionId` (persistent UUID) and `auth.initCommand` (URL-derived).
+2. `checkRateLimit(ip)` → reject if exceeded.
+3. If `sessionId` matches an existing session/zombie → `restoreByPersistentSessionId`, slot taken.
+4. Else if `ipSessions` already has this IP → kick the old socket+container, then create a fresh session.
+5. `createSession` → `_grabFromPool()` if available; else `createContainerSession` (slow path).
+6. Wait for `promptSeen` (zsh prompt rendered) AND `firstResizeApplied` (client sent dimensions). 6-second fallback releases the gate at the pre-resize 140×40 dimensions.
+7. Auto-type the `initCommand` (default `welcome`) char-by-char for `welcome` (animated), atomically for everything else (`autoTypeCommand`, `session.js:545`).
+
+## InitCommand validation
+
+`autoTypeCommand` re-validates the command using the same regex/heads list as the frontend: `/^[a-z0-9 ._/+=:,@-]+$/i`, length ≤ 200. Anything that fails falls back to `welcome` rather than rejecting outright.
+
+## Orphan cleanup
+
+`cleanupOrphanedContainers` runs every 60 s (`server.js:227`). Lists all containers with label `app=terminal-portfolio`, kills any that aren't in the live `sessions` map and aren't in the warm `pool`. On startup, `cleanupDockerSmart` removes leftover portfolio containers from the previous backend run plus all but the newest portfolio image.
+
+## Things to watch
+
+- `_handleStreamClose` (`session.js:632`) covers both live and zombified sessions. Without it, a container that dies after zombification would persist until the 30s timer fires and a reconnect would land in a blank session.
+- `inAltScreen` tracking (`\x1b[?1049h/l` and `\x1b[?47h/l`) is required for nvim/htop reattach: on socket swap we re-emit the alt-screen-enter sequence to the new xterm.js so the redraw lands in the right buffer.
+- The pool's data handler is detached during welcome warm-up to avoid prompt bleed (`session.js:152`); on lease, the buffered prompt is replayed but new output goes through `session._streamDataHandler`.
+- Don't add EXEC to the socket-proxy env. The lease path doesn't need it; enabling it would expose `docker exec` to a compromised backend.

--- a/container/AGENTS.md
+++ b/container/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/container/CLAUDE.md
+++ b/container/CLAUDE.md
@@ -1,0 +1,62 @@
+# container/
+
+Source for the `twaldin/terminal-portfolio:latest` Docker image — the Ubuntu sandbox that every visitor lands in. Built with `container/build.sh` (`docker build -t twaldin/terminal-portfolio:latest ./container`). The backend's `SessionManager` looks up this exact tag in `backend/session.js:240` and warns on startup if it's missing.
+
+## Layout
+
+```
+container/
+├── Dockerfile              # Ubuntu 24.04 → zsh + Oh My Posh + nvim nightly + scripts
+├── build.sh                # docker build helper
+├── DOS_Rebel.flf           # Custom figlet font (copied to /usr/share/figlet/)
+├── Univers.flf
+├── blog/posts/             # Markdown blog posts (copied to /home/portfolio/blog/)
+└── scripts/                # Portfolio shell scripts (copied to /home/portfolio/scripts/)
+    ├── shared-functions.sh # colors, typewriter, ascii_typewriter, create_box, emit_url
+    ├── welcome.sh          # Home page (figlet "twaldin" + portfolio menu box)
+    ├── auto-welcome.sh
+    ├── projects.sh         # List of projects with descriptions
+    ├── about.sh            # About me
+    ├── contact.sh          # Email + socials via OSC 8 hyperlinks
+    ├── resume.sh           # Resume page with clickable PDF link
+    ├── blog.sh             # Markdown rendering via mdcat (fallback: glow)
+    ├── help.sh             # Available commands
+    └── flt.sh, agentelo.sh, hone.sh, harness.sh,
+        stm32-games.sh, term-site.sh, trade-up-bot.sh,
+        skyblock-qol.sh, dotfiles.sh   # Per-project pages
+```
+
+## Image build (Dockerfile highlights)
+
+- **Base**: `ubuntu:24.04`. Packages installed in one layer for cache efficiency: zsh, neovim, vim, nano, ripgrep, fzf, less, bat, git, tree, htop, figlet, fontconfig.
+- **Markdown**: `mdcat` (primary; emits OSC 8 hyperlinks so xterm.js renders clickable link text without printing the raw URL) and `glow` as fallback. `blog.sh` prefers `mdcat` when both are present.
+- **Editor**: `bob` neovim version manager → `bob install nightly` (the dotfiles nvim config uses `vim.pack` and other nightly features). Plugins are baked into the image at build time (`yes A | nvim --headless +qa`) because the runtime container has `NetworkMode: none`.
+- **Font**: JetBrains Mono Nerd Font v3.0.2 installed under `~/.local/share/fonts/`.
+- **Prompt**: Oh My Posh + the `pure-modified.omp.json` from the dotfiles repo, with `{{ .UserName }}` `sed`-replaced to `tim.waldin.net` so the prompt reads `tim.waldin.net ~`.
+- **Repos**: dotfiles + project repos cloned into `/home/portfolio/projects/` at build time. Each repo gets a per-script symlink (`projects/flt/flt.sh -> ../../scripts/flt.sh`, etc.) so the navigation aliases work from inside the project dir.
+- **sudo**: passwordless `sudo` for `portfolio`. Safe because all Linux capabilities are dropped at the Docker level — `sudo rm -rf /` works inside the container as a demo, but can't escape.
+
+## Shell wiring (`.zshrc`)
+
+The Dockerfile builds a custom `.zshrc` that:
+
+1. `source`s the dotfiles `zshrc`, then disables `PROMPT_CR` (zsh's partial-line `%` marker) for cleaner output.
+2. Defines aliases for every portfolio command (`welcome`, `home`, `projects`, `about`, `contact`, `resume`, `blog`, `help`, plus per-project aliases like `flt`, `agentelo`, `term-site`, `stm32-games`, etc.). Each alias `cd`s into the right directory and runs the corresponding script.
+3. Loads `shared-functions.sh` for `emit_url` (the OSC 9999 emitter).
+4. Defines a `preexec` hook that re-emits an OSC 9999 URL before every typed command so the browser URL tracks whatever the user typed. Same `SAFE_CMD_RE` and blocked-heads list as the frontend's `pathToCommand` (`websocket.ts`) — keep the two in sync.
+5. Initialises Oh My Posh with `pure-modified.omp.json`.
+
+## URL emission protocol
+
+Scripts and `preexec` write `\033]9999;<path>\007` to stdout via `emit_url` (defined in `shared-functions.sh`). The frontend's `OSC 9999` handler (`frontend/src/components/Terminal.tsx:99`) calls `history.pushState` with that path. Conventions:
+
+- `welcome` / `home` → empty path (`/`).
+- Project aliases → `projects/<alias>` (matches the legacy pretty URL the frontend recognises).
+- Anything else → URL-encoded raw command (`emit_url "${cmd// /%20}"`).
+
+## Things to watch
+
+- `term-site` is a private repo at clone time — the Dockerfile masks the failure with `(git clone ... || mkdir -p term-site)`. If the project is made public, the visitor's `term-site` page will pick up live git activity automatically.
+- `typst-preview.nvim` is `sed`-stripped from the dotfiles nvim init at build time because it spawns a system browser, which can't work in a sandbox with no network.
+- Mason LSP server fetches fail at build time (`curl` is missing in mason's runtime path) — harmless, plugins are still cloned via `vim.pack`. The `|| true` on the mason install RUN line is intentional.
+- `nvm` is installed so the dotfiles `load-nvmrc` hook resolves; we don't actually need a Node runtime in the container.

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -1,0 +1,73 @@
+# frontend/
+
+Next.js 15 (App Router, Turbopack) + React 19 client that renders the xterm.js terminal and brokers Socket.IO traffic to the backend. Tailwind 4 for the chrome around the terminal; the terminal itself is themed via the xterm.js options object (`src/config/terminal-theme.ts`) using Gruvbox Dark.
+
+## Layout
+
+```
+src/
+├── app/
+│   ├── layout.tsx          # Nerd Font preload + dark colorScheme + SiteHeader
+│   ├── page.tsx            # Home: mounts <Terminal>, wires WebSocket manager, TTI marks
+│   ├── globals.css
+│   ├── not-found.tsx
+│   ├── blog/[slug]/        # Static blog page (cold) — links to /t/<cmd> for live term
+│   └── [...slug]/          # Catch-all that maps URL → initCommand at connect time
+├── components/
+│   ├── Terminal.tsx        # The only xterm.js mount in the app
+│   ├── BlogRouter.tsx
+│   ├── BlogUnifiedPage.tsx
+│   └── SiteHeader.tsx
+├── config/terminal-theme.ts
+└── lib/
+    ├── websocket.ts        # Socket.IO client + URL→command sync + safety lists
+    ├── xterm-touch.ts      # Mobile pan/scroll handling
+    ├── markdown-components.tsx
+    └── routes.ts           # Per-path metadata + canonical URL helpers
+```
+
+## Terminal component (`components/Terminal.tsx`)
+
+- Single xterm.js instance, mounted client-side only (`dynamic(import, { ssr: false })` in `app/page.tsx:9`).
+- Addons loaded: `FitAddon`, `WebglAddon` (with canvas fallback on context loss), `WebLinksAddon` (deferred until first hover to keep TTI cheap).
+- Font: JetBrainsMono Nerd Font, preloaded as woff2 in `app/layout.tsx:47-60`. xterm boots with a system fallback first; `document.fonts.ready` triggers a re-fit when the Nerd Font swap-in changes glyph widths (`Terminal.tsx:160-165`).
+- Dynamic font sizing in `calculateFontSize()` (`Terminal.tsx:25-35`): viewport-width-driven, clamped 10–28 px, mobile branch derives target cols from `usableWidth / (MIN_FONT_SIZE * 0.6)`. Cols/rows fall out of `FitAddon` rather than being set explicitly so figlet boxes scale naturally.
+- Touch scroll handling lives in `lib/xterm-touch.ts` (mobile pan, momentum, dead-zone above the keyboard).
+
+## OSC handlers — URL ↔ command sync
+
+The container's zsh `preexec` hook emits OSC sequences that the frontend parses to keep the URL in sync with what's running in the shell:
+
+- **OSC 9999** (`Terminal.tsx:99`): `\x1b]9999;<path>\x07` → `history.pushState` to `/<path>`. Used by `welcome`, project pages, blog, etc. Same-origin only.
+- **OSC 9998** (`Terminal.tsx:109`): scroll terminal to top.
+- **OSC 9997** (`Terminal.tsx:114`): hard-navigate via `location.assign` — used when the shell wants the browser to leave the terminal page entirely (e.g. blog cold page). Strips leading slashes and rejects scheme-prefixed input.
+- **OSC 8** hyperlinks: standard terminal hyperlinks. Activation is overridden via `xterm.options.linkHandler` to open in a new tab (`Terminal.tsx:81-87`).
+
+## Socket.IO client (`lib/websocket.ts`)
+
+- Persistent `sessionId` stored in `localStorage` under `terminal-session-id` (UUID v4, generated lazily). Sent in the Socket.IO handshake `auth` so backend reattach works across refresh.
+- `pathToCommand(pathname)` (`websocket.ts:26`): maps the current URL to the `initCommand` that gets sent in the handshake. Rules:
+  - `/` → `welcome`
+  - `/t/<cmd>` → `<cmd>` (forces live terminal, used by blog cold pages)
+  - `/projects/<alias>` → `<alias>` (legacy pretty URL, only for known aliases)
+  - Anything else → URL-decoded path, validated against `SAFE_CMD_RE` and `BLOCKED_HEADS`. Spaces decode from `%20`; a leading `/` separator (e.g. `/blog/foo`) is converted to a space (`blog foo`).
+- Two safety lists also enforced backend-side as defence-in-depth:
+  - `SAFE_CMD_RE` = `/^[A-Za-z0-9 ._/+=:,@-]+$/` — blocks shell metachars.
+  - `BLOCKED_HEADS` = `rm`, `mv`, `cp`, `dd`, `sudo`, `su`, `chmod`, `chown`, `kill`, `pkill`, `killall`, `sh`, `bash`, `zsh`, `dash`, `eval`, `exec`, `source`, `mkfs`, `mount`, `umount`, `exit`, `logout`.
+
+## Blog: static cold + live hot
+
+The blog has two modes: `app/blog/[slug]/page.tsx` is a static (SSR) markdown render for fast first paint and SEO; once the user interacts, the page hands over to the live terminal via a `/t/blog%20<slug>` link. The handoff sends an empty-string `initCommand` to the backend (sentinel: don't auto-type, don't overwrite the user's input) — see `backend/session.js:664`.
+
+## Dev / build
+
+- `pnpm dev` → Next 15 with Turbopack on port 3000 (`package.json` script: `next dev --turbopack --port 3000`).
+- `pnpm build` / `pnpm start` for production.
+- Vitest unit tests in `src/lib/__tests__/`.
+- Production image: `frontend/Dockerfile.production`. Runs read-only with a 50MB tmpfs at `/tmp` (see `docker-compose.yml:33-37`).
+
+## Things to watch
+
+- xterm references `self` at module load — keep `Terminal.tsx` behind `next/dynamic` with `ssr: false`. Removing that breaks `next build`.
+- Resize is a *passive* signal in the backend (it doesn't reset idle timers); don't try to use it as a heartbeat.
+- The persistent `sessionId` is per-browser, not per-tab — opening a new tab from the same browser hits the IP-pinned-session collapse logic in the backend, not a fresh-session path.


### PR DESCRIPTION
## Summary
- Replaces the previously gitignored, per-spawn flt agent CLAUDE.md with canonical project-foundation docs at the repo root and at `frontend/`, `backend/`, and `container/`. Each location also gets an `AGENTS.md` symlink → `CLAUDE.md` so tools that look for either name resolve to the same canonical content.
- Documents the actual runtime model: a **pre-warmed pool of 5 containers** (`backend/session.js:31`) leased one-per-visitor-IP, with a hard cap of 40 concurrent sessions. Same-IP reconnects either reattach the existing container (when the persistent `localStorage` `sessionId` matches) or kick the old socket and take the slot — see the IP-pinned-session + tab-collapse rules in `backend/server.js:54-131`.
- Removes the `CLAUDE.md` line from `.gitignore`. The flt block at the bottom of root `CLAUDE.md` is preserved between its `<!-- flt:start -->` / `<!-- flt:end -->` markers so future flt spawns can keep regenerating their agent role inside those markers without touching the project content above.

## Test plan
- [ ] Confirm symlinks resolve: `cat AGENTS.md` matches `cat CLAUDE.md` at every level.
- [ ] Confirm the four files render correctly on GitHub's PR view.
- [ ] Sanity-check that a fresh `flt` spawn writes its agent role between the existing markers and leaves the project docs untouched.