### PR TITLE
fix: prevent admin auth length mismatch errors

### DIFF
--- a/backend/admin.js
+++ b/backend/admin.js
@@ -1,8 +1,18 @@
 const express = require('express');
-const { timingSafeEqual } = require('crypto');
+const { timingSafeEqual, createHmac, randomBytes } = require('crypto');
 const { readAll } = require('./logger');
 
 const router = express.Router();
+
+// Random key generated at startup; used only to normalize HMAC output to a
+// fixed 32-byte length so timingSafeEqual never receives mismatched-length
+// buffers (which would throw RangeError and produce a 500 instead of 401).
+const HMAC_KEY = randomBytes(32);
+function safeEqual(a, b) {
+  const ha = createHmac('sha256', HMAC_KEY).update(a).digest();
+  const hb = createHmac('sha256', HMAC_KEY).update(b).digest();
+  return timingSafeEqual(ha, hb);
+}
 
 function basicAuth(req, res, next) {
   const password = process.env.ADMIN_PASSWORD;
@@ -20,10 +30,9 @@ function basicAuth(req, res, next) {
   const user = idx >= 0 ? decoded.slice(0, idx) : decoded;
   const pass = idx >= 0 ? decoded.slice(idx + 1) : '';
   const email = process.env.ADMIN_EMAIL || 'timothy@waldin.net';
-  // Constant-time comparison to prevent timing-based brute-force
-  const userMatch = timingSafeEqual(Buffer.from(user), Buffer.from(email));
-  const passMatch = timingSafeEqual(Buffer.from(pass), Buffer.from(password));
-  if (!userMatch || !passMatch) {
+  // Constant-time comparison via HMAC digest (fixed 32-byte output regardless
+  // of input length, so timingSafeEqual never throws on length mismatch)
+  if (!safeEqual(user, email) || !safeEqual(pass, password)) {
     res.set('WWW-Authenticate', 'Basic realm="term-site admin"');
     return res.status(401).send('Invalid credentials.');
   }
@@ -237,3 +246,5 @@ function filter(){
 });
 
 module.exports = router;
+module.exports._basicAuth = basicAuth;
+module.exports._safeEqual = safeEqual;

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "node server.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node test-admin-auth.js"
   },
   "keywords": [],
   "author": "",

--- a/backend/test-admin-auth.js
+++ b/backend/test-admin-auth.js
@@ -1,0 +1,128 @@
+'use strict';
+// Minimal regression tests for admin basicAuth — no test framework required.
+// Run: node backend/test-admin-auth.js
+const assert = require('assert');
+
+let passed = 0;
+function ok(label, fn) {
+  try {
+    fn();
+    console.log(`  ok  ${label}`);
+    passed++;
+  } catch (e) {
+    console.error(`FAIL  ${label}`);
+    console.error('      ' + e.message);
+    process.exitCode = 1;
+  }
+}
+
+// ── safeEqual unit tests ──────────────────────────────────────────────────────
+const { _safeEqual: safeEqual } = require('./admin.js');
+
+ok('safeEqual: identical strings match', () =>
+  assert.strictEqual(safeEqual('abc', 'abc'), true));
+
+ok('safeEqual: different strings do not match', () =>
+  assert.strictEqual(safeEqual('abc', 'xyz'), false));
+
+ok('safeEqual: different lengths do not throw', () =>
+  assert.doesNotThrow(() => safeEqual('short', 'a-much-longer-string')));
+
+ok('safeEqual: different lengths return false', () =>
+  assert.strictEqual(safeEqual('short', 'a-much-longer-string'), false));
+
+ok('safeEqual: empty vs non-empty does not throw', () =>
+  assert.doesNotThrow(() => safeEqual('', 'password')));
+
+ok('safeEqual: empty vs non-empty returns false', () =>
+  assert.strictEqual(safeEqual('', 'password'), false));
+
+ok('safeEqual: empty vs empty matches', () =>
+  assert.strictEqual(safeEqual('', ''), true));
+
+// ── basicAuth middleware integration tests ────────────────────────────────────
+process.env.ADMIN_EMAIL = 'admin@example.com';
+process.env.ADMIN_PASSWORD = 'correct-password';
+
+// Re-require after env is set so the module picks up the env vars at call time
+const { _basicAuth: basicAuth } = require('./admin.js');
+
+function makeReq(authHeader) {
+  return { headers: { authorization: authHeader || '' } };
+}
+
+function makeRes() {
+  let statusCode = null;
+  const headers = {};
+  const res = {
+    _statusCode: null,
+    _body: null,
+    status(code) { res._statusCode = code; return res; },
+    send(body) { res._body = body; return res; },
+    set(k, v) { headers[k] = v; return res; },
+    headers,
+  };
+  return res;
+}
+
+function encode(user, pass) {
+  return 'Basic ' + Buffer.from(`${user}:${pass}`).toString('base64');
+}
+
+ok('basicAuth: no auth header → 401', () => {
+  const res = makeRes();
+  let nextCalled = false;
+  basicAuth(makeReq(''), res, () => { nextCalled = true; });
+  assert.strictEqual(res._statusCode, 401);
+  assert.strictEqual(nextCalled, false);
+});
+
+ok('basicAuth: wrong username (different length) → 401, not 500', () => {
+  const res = makeRes();
+  let nextCalled = false;
+  basicAuth(makeReq(encode('x', 'correct-password')), res, () => { nextCalled = true; });
+  assert.strictEqual(res._statusCode, 401);
+  assert.strictEqual(nextCalled, false);
+});
+
+ok('basicAuth: wrong password (different length) → 401, not 500', () => {
+  const res = makeRes();
+  let nextCalled = false;
+  basicAuth(makeReq(encode('admin@example.com', 'wrong')), res, () => { nextCalled = true; });
+  assert.strictEqual(res._statusCode, 401);
+  assert.strictEqual(nextCalled, false);
+});
+
+ok('basicAuth: empty user and pass → 401, not 500', () => {
+  const res = makeRes();
+  basicAuth(makeReq(encode('', '')), res, () => {});
+  assert.strictEqual(res._statusCode, 401);
+});
+
+ok('basicAuth: correct credentials → next() called', () => {
+  const res = makeRes();
+  let nextCalled = false;
+  basicAuth(makeReq(encode('admin@example.com', 'correct-password')), res, () => { nextCalled = true; });
+  assert.strictEqual(res._statusCode, null, 'should not set status on success');
+  assert.strictEqual(nextCalled, true);
+});
+
+ok('basicAuth: password with colon is handled correctly', () => {
+  process.env.ADMIN_PASSWORD = 'pass:with:colons';
+  const res = makeRes();
+  let nextCalled = false;
+  basicAuth(makeReq(encode('admin@example.com', 'pass:with:colons')), res, () => { nextCalled = true; });
+  assert.strictEqual(nextCalled, true);
+  process.env.ADMIN_PASSWORD = 'correct-password';
+});
+
+ok('basicAuth: no ADMIN_PASSWORD → 503', () => {
+  const saved = process.env.ADMIN_PASSWORD;
+  delete process.env.ADMIN_PASSWORD;
+  const res = makeRes();
+  basicAuth(makeReq(encode('admin@example.com', 'x')), res, () => {});
+  assert.strictEqual(res._statusCode, 503);
+  process.env.ADMIN_PASSWORD = saved;
+});
+
+console.log(`\n${passed} tests passed.`);


### PR DESCRIPTION
## Summary
- Replace direct timingSafeEqual credential buffer comparisons with fixed-length HMAC digest comparisons
- Return 401 for wrong-length or malformed Basic Auth credentials instead of throwing RangeError/500
- Add a minimal backend auth regression test and wire backend npm test to run it

## Root cause
Production backend logs showed RangeError: Input buffers must have the same byte length at backend/admin.js basicAuth. crypto.timingSafeEqual throws when compared buffers have different lengths, so a wrong username/password length escaped as Express 500. Express's default error response includes Content-Security-Policy: default-src 'none', matching the reported browser symptom.

## Verification
- npm test --prefix backend
- npm --prefix frontend test -- --run
- local Express smoke: no auth, short username, short password all return 401
- production pre-fix reproduction: curl with short username returns 500 and CSP default-src 'none'