### PR TITLE
Make pre-warm container pool self-healing

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -225,6 +225,9 @@ app.get('/stats', (req, res) => {
 // Admin panel
 app.use('/admin', adminRouter);
 
+// Keep the pre-warm pool topped up — self-heals if idle pool streams drain it.
+sessionManager.startPoolMaintenance();
+
 // Periodic orphan cleanup every 60 seconds
 setInterval(() => {
   sessionManager.cleanupOrphanedContainers();

--- a/backend/session.js
+++ b/backend/session.js
@@ -30,6 +30,7 @@ class SessionManager {
     this.pool = [];
     this.poolSize = 5;
     this.poolWarming = 0;
+    this._poolBackoffMs = 0;
     this.zombieSessions = new Map();
     // Resizes that arrive before the session is stored (fresh container path)
     // are buffered here and applied once the session is ready.
@@ -83,9 +84,30 @@ class SessionManager {
     while (this.pool.length + this.poolWarming < this.poolSize) {
       this.poolWarming++;
       this.warmOne()
-        .catch((err) => console.error('warmOne failed:', err.message))
+        .then(() => { this._poolBackoffMs = 0; })
+        .catch((err) => {
+          console.error('warmOne failed:', err.message);
+          // Exponential backoff so a transient socket-proxy/DNS failure
+          // (EAI_AGAIN) doesn't spin. Capped at 30s. The periodic
+          // maintenance loop (startPoolMaintenance) retries after this.
+          this._poolBackoffMs = Math.min((this._poolBackoffMs || 0) * 2 || 1000, 30000);
+          this._lastWarmFailAt = Date.now();
+        })
         .finally(() => { this.poolWarming--; });
     }
+  }
+
+  startPoolMaintenance() {
+    if (this._poolMaintTimer) return; // single-flight
+    this._poolMaintTimer = setInterval(() => {
+      if (!this.imagePreloaded) return;
+      // Honor backoff window after a recent failure.
+      if (this._poolBackoffMs && this._lastWarmFailAt &&
+          Date.now() - this._lastWarmFailAt < this._poolBackoffMs) return;
+      if (this.pool.length < this.poolSize) {
+        this.fillPool();
+      }
+    }, 15 * 1000); // top up every 15s
   }
 
   async warmOne() {
@@ -120,6 +142,7 @@ class SessionManager {
     item._onClose = () => {
       item.alive = false;
       this.pool = this.pool.filter((p) => p !== item);
+      console.log(`Pool: container stream closed, ${this.pool.length}/${this.poolSize} ready (will top up)`);
     };
     stream.on('data', item._onData);
     stream.on('close', item._onClose);
@@ -300,6 +323,9 @@ class SessionManager {
       this.fillPool();
       return this.attachPooledSession(sessionId, socket, initCommand, pooled, clientIP, persistentSessionId);
     }
+    // Pool was empty — start refilling for the next visitor, then serve this
+    // one on the slow path.
+    this.fillPool();
     return this.createContainerSession(sessionId, socket, initCommand, clientIP, persistentSessionId);
   }
 

--- a/backend/test-pool-maintenance.js
+++ b/backend/test-pool-maintenance.js
@@ -1,0 +1,122 @@
+'use strict';
+// Unit tests for the self-healing pre-warm pool control logic — no Docker.
+// We stub warmOne so no real containers are created.
+// Run: node backend/test-pool-maintenance.js
+const assert = require('assert');
+
+let passed = 0;
+function ok(label, fn) {
+  try {
+    fn();
+    console.log(`  ok  ${label}`);
+    passed++;
+  } catch (e) {
+    console.error(`FAIL  ${label}`);
+    console.error('      ' + e.message);
+    process.exitCode = 1;
+  }
+}
+
+const SessionManager = require('./session.js');
+
+// Stub preloadImage on the prototype BEFORE constructing so the constructor's
+// startup `preloadImage().then(fillPool)` never touches Docker or spins the
+// 30s docker-wait retry loop (which would keep the process alive).
+SessionManager.prototype.preloadImage = function () { return Promise.resolve(); };
+
+// Build a manager with warmOne stubbed BEFORE any real warming can occur.
+// The constructor's preloadImage() resolves async and only fills when
+// imagePreloaded is true; we control that and warmOne directly here.
+function makeManager() {
+  const mgr = new SessionManager();
+  // Neutralize the docker client so nothing real is touched.
+  mgr.docker = null;
+  mgr.imagePreloaded = true;
+  mgr.pool = [];
+  mgr.poolWarming = 0;
+  mgr._poolBackoffMs = 0;
+  mgr._lastWarmFailAt = undefined;
+  return mgr;
+}
+
+// Drain the microtask/timer queues so the .then/.catch/.finally on warmOne settle.
+function settle() {
+  return new Promise((r) => setImmediate(r));
+}
+
+// ── Case 1: fillPool schedules up to poolSize warm attempts ──────────────────
+(async () => {
+  await new Promise((done) => {
+    const mgr = makeManager();
+    let calls = 0;
+    mgr.warmOne = () => {
+      calls++;
+      // Simulate a successful warm. The REAL warmOne only pushes to the pool
+      // after async work resolves, so push asynchronously here too — otherwise
+      // pool.length would grow mid-loop and short-circuit the while condition.
+      return Promise.resolve().then(() => { mgr.pool.push({ alive: true }); });
+    };
+
+    mgr.fillPool();
+
+    // poolWarming should have been incremented up to poolSize synchronously.
+    ok('case1: poolWarming incremented to poolSize synchronously', () =>
+      assert.strictEqual(mgr.poolWarming, mgr.poolSize));
+
+    settle().then(() => settle()).then(() => {
+      ok('case1: warmOne called poolSize times', () =>
+        assert.strictEqual(calls, mgr.poolSize));
+      ok('case1: poolWarming returns to 0 after settle', () =>
+        assert.strictEqual(mgr.poolWarming, 0));
+      ok('case1: pool is full', () =>
+        assert.strictEqual(mgr.pool.length, mgr.poolSize));
+      ok('case1: backoff reset to 0 on success', () =>
+        assert.strictEqual(mgr._poolBackoffMs, 0));
+      done();
+    });
+  });
+
+  // ── Case 2: warmOne rejection → no throw, poolWarming 0, backoff grows ──────
+  await new Promise((done) => {
+    const mgr = makeManager();
+    let calls = 0;
+    mgr.warmOne = () => {
+      calls++;
+      return Promise.reject(new Error('getaddrinfo EAI_AGAIN socket-proxy'));
+    };
+
+    ok('case2: fillPool does not throw on rejecting warmOne', () =>
+      assert.doesNotThrow(() => mgr.fillPool()));
+
+    settle().then(() => settle()).then(() => {
+      ok('case2: warmOne attempted poolSize times', () =>
+        assert.strictEqual(calls, mgr.poolSize));
+      ok('case2: poolWarming returns to 0', () =>
+        assert.strictEqual(mgr.poolWarming, 0));
+      ok('case2: _poolBackoffMs increased above 0', () =>
+        assert.ok(mgr._poolBackoffMs > 0, `expected >0, got ${mgr._poolBackoffMs}`));
+      ok('case2: _poolBackoffMs is capped at 30000', () =>
+        assert.ok(mgr._poolBackoffMs <= 30000, `expected <=30000, got ${mgr._poolBackoffMs}`));
+      ok('case2: _lastWarmFailAt recorded', () =>
+        assert.strictEqual(typeof mgr._lastWarmFailAt, 'number'));
+      done();
+    });
+  });
+
+  // ── Case 3: startPoolMaintenance is idempotent ──────────────────────────────
+  {
+    const mgr = makeManager();
+    mgr.warmOne = () => Promise.resolve();
+    mgr.startPoolMaintenance();
+    const firstTimer = mgr._poolMaintTimer;
+    ok('case3: maintenance timer is set after first call', () =>
+      assert.ok(firstTimer, 'expected _poolMaintTimer to be set'));
+    mgr.startPoolMaintenance();
+    ok('case3: second call does not create a new timer (idempotent)', () =>
+      assert.strictEqual(mgr._poolMaintTimer, firstTimer));
+    // Clear so the process can exit.
+    clearInterval(mgr._poolMaintTimer);
+  }
+
+  console.log(`\n${passed} tests passed.`);
+})();


### PR DESCRIPTION
## What

Implements **plan 002** (`plans/002-self-healing-pool.md`): makes the pre-warmed container pool recover on its own instead of dying permanently.

## Why

Verified on the production VPS over SSH: the pool fills to `5/5` at boot, drains within minutes (idle attach streams close → `_onClose` empties `this.pool`), and **never refills** — the only refill trigger was a *successful* pool grab (`createSession`). Result over 2 days of traffic: **18 cold container creates, 0 pooled assigns**. Every visitor paid the 1–2 s cold-start the pool exists to eliminate.

## Changes (`backend/`)

- **`session.js`** — `fillPool()` is now single-flight-safe with exponential backoff (caps at 30 s) so transient `EAI_AGAIN socket-proxy` DNS failures don't spin or wedge the pool. New idempotent `startPoolMaintenance()` (15 s interval) tops the pool back up whenever `pool.length < poolSize`, honoring the backoff window — this is what makes it self-healing regardless of why an item drained. `createSession()` now also calls `fillPool()` on the cold-miss branch. Diagnostic log added to the pool `_onClose` handler.
- **`server.js`** — calls `sessionManager.startPoolMaintenance()` at boot, next to the orphan-cleanup interval.
- **`test-pool-maintenance.js`** (new) — stubs `warmOne`/`preloadImage` (no Docker), asserts single-flight + backoff math + balanced `poolWarming` accounting + idempotent maintenance timer.

Container sandbox `HostConfig`, `poolSize` (5), `maxSessions` (40), the welcome warm-up, and zombie/reattach logic are all unchanged.

## Verification

- `node --check backend/session.js && node --check backend/server.js` → clean
- `node backend/test-pool-maintenance.js` → 13/13 pass
- `cd backend && npm test` → 14/14 pass (admin-auth unbroken)

Produced via an isolated-worktree workflow: implement → 3-lens adversarial review (correctness / scope / done-criteria) → independent re-verify, then reviewed and all gates re-run by hand before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented automatic session pool maintenance with exponential backoff recovery from warm-up failures
  * Added scheduled background pool refilling when session capacity becomes depleted to improve availability
  * Enhanced pool event logging for better visibility into resource health

* **Tests**
  * Added unit test suite validating session pool maintenance and failure recovery behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->