### PR TITLE
Prune stale Docker build cache on deploy

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -16,6 +16,13 @@ echo "Building and starting services..."
 docker compose build --no-cache
 docker compose up -d --force-recreate
 
+# Reclaim disk: remove dangling images and ALL build cache left by the
+# --no-cache builds above. Safe — only removes data not used by a running
+# container. Never prunes volumes (backend_data holds the audit log).
+echo "Pruning stale Docker build cache and dangling images..."
+docker image prune -f
+docker builder prune -f
+
 # Wait for services to initialize
 echo "Waiting for services to initialize..."
 sleep 5

--- a/scripts/vps-prune.sh
+++ b/scripts/vps-prune.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Reclaim Docker disk on the VPS: dangling images + all build cache.
+# Does NOT touch volumes (backend_data audit log) or running containers.
+#
+# Usage:
+#   scripts/vps-prune.sh            show reclaimable, then prune
+set -euo pipefail
+source "$(dirname "$0")/lib/common.sh"
+
+require_cmd ssh
+require_vps_reachable
+
+log_step "Disk usage before prune"
+on_vps "docker system df"
+
+log_step "Pruning dangling images + build cache (volumes untouched)"
+on_vps "docker image prune -f && docker builder prune -f"
+
+log_step "Disk usage after prune"
+on_vps "docker system df && df -h / | tail -1"
+log_ok "Prune complete"


### PR DESCRIPTION
## What

Implements **plan 001** (`plans/001-reclaim-docker-disk.md`): stops the production VPS from filling its disk with stale Docker build cache, and adds a standalone reclaim script.

## Why

Measured live on the VPS: root disk is **83% full (60/75 GB)**, and `docker system df` shows **52.8 GB of build cache (52.45 GB reclaimable) + 50 GB of images (46.5 GB reclaimable)** — ~92% reclaimable. Cause: `deploy.sh` runs `docker compose build --no-cache` every deploy, and nothing ever prunes the orphaned layers/dangling images. If the disk hits 100% the site goes down (backend can't create session containers, certbot can't renew).

## Changes

- **`deploy.sh`** — adds `docker image prune -f` + `docker builder prune -f` immediately **after** `docker compose up -d --force-recreate`, so the freshly-started containers' image layers are in-use and protected. Uses `image prune` **without `-a`** (removes only dangling images — the tagged `twaldin/terminal-portfolio:latest` session image is never at risk). `--no-cache` is intentionally kept.
- **`scripts/vps-prune.sh`** (new) — standalone reclaim the operator can run between deploys: shows `docker system df`, prunes images + build cache over SSH via the existing `lib/common.sh` helpers, shows disk usage after.

**Safety:** `docker volume prune` appears nowhere — the `backend_data` audit-log volume is never touched. `docker-compose.yml` is unchanged.

## Verification

- `bash -n deploy.sh` and `bash -n scripts/vps-prune.sh` → exit 0
- `grep -rn "volume prune" deploy.sh scripts/vps-prune.sh` → no matches

Produced via an isolated-worktree workflow: implement → 3-lens adversarial review (correctness/safety, scope, done-criteria) → independent re-verify, then reviewed and gates re-run by hand before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
