### PR TITLE
Use Next.js standalone output for slim frontend image

### DIFF
--- a/frontend/Dockerfile.production
+++ b/frontend/Dockerfile.production
@@ -21,21 +21,20 @@ WORKDIR /app
 RUN addgroup -g 1001 -S nextjs && \
     adduser -S nextjs -u 1001 -G nextjs
 
-# Copy built application
-COPY --from=builder /app/.next ./.next
-COPY --from=builder /app/public ./public
-COPY --from=builder /app/package.json /app/pnpm-lock.yaml ./
-COPY --from=builder /app/next.config.ts ./
+ENV NODE_ENV=production
 
-# Install all deps (not just prod) — Next.js needs typescript at runtime
-# to parse next.config.ts. Enable corepack and chown before USER switch.
-RUN corepack enable && pnpm install --frozen-lockfile && \
-    chown -R nextjs:nextjs /app
+# Standalone server bundle (includes a pruned node_modules + compiled config).
+COPY --from=builder --chown=nextjs:nextjs /app/.next/standalone ./
+# Static assets and public files are NOT in standalone — copy them in.
+COPY --from=builder --chown=nextjs:nextjs /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nextjs /app/public ./public
+# Blog markdown is read from disk at request time; standalone tracing omits it.
+COPY --from=builder --chown=nextjs:nextjs /app/blog-posts ./blog-posts
 
 USER nextjs
 
 EXPOSE 3000
 
-ENV NODE_ENV=production
-
-CMD ["npx", "next", "start"]
+# Standalone emits server.js at the app root; run it directly (no next CLI,
+# no TypeScript, no pnpm install needed at runtime).
+CMD ["node", "server.js"]

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: "standalone",
 };
 
 export default nextConfig;


### PR DESCRIPTION
## What

Implements **plan 003** (`plans/003-frontend-standalone-image.md`): switches the frontend to Next.js `output: 'standalone'`, shrinking the production image **1.39 GB → 328 MB** (–76%).

## Why

The old `frontend/Dockerfile.production` ran `pnpm install --frozen-lockfile` with **all** deps in the production stage (typescript, eslint, tailwind, vitest…) because `npx next start` parsed `next.config.ts` at runtime. Standalone output traces the minimal runtime dependency set and emits a self-contained `server.js`, so the prod image needs no `node_modules` install and no TypeScript.

## Changes

- **`frontend/next.config.ts`** — `output: "standalone"`.
- **`frontend/Dockerfile.production`** — prod stage now copies the standalone bundle (`.next/standalone` → app root, `.next/static`, `public`, and `blog-posts`) with `--chown=nextjs:nextjs`, runs `CMD ["node","server.js"]`, and no longer runs `pnpm install`.

`blog-posts/` is copied in because the `/blog/[slug]` route can `readFileSync` at request time for non-prerendered slugs (defensive — the 3 known slugs are SSG-prebuilt).

## Verification

Built and smoke-tested under the **same constraints as `docker-compose.yml`** (`--read-only`, `--tmpfs /tmp`, `no-new-privileges`):
- image size **328 MB** (target <500 MB)
- `/` → **200**, `/blog/2026-04-19-hone-haiku-20pp` → **200**, static assets present
- prod stage no longer runs `pnpm install`

Produced via isolated-worktree workflow: implement → 3-lens adversarial review (correctness/runtime, scope, done-criteria) → independent re-verify; diff reviewed and image re-built + smoke-tested by hand before push.

### Follow-ups (not in this PR)
- Unknown blog slugs return a correct 404 but log `EROFS` noise (Next tries to write a prerender-cache file under the read-only rootfs). **Pre-existing** — same behavior under the old `npx next start`. Cheap future fix: `export const dynamicParams = false` on the blog route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized production deployment configuration for improved efficiency and faster application startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->