### PR TITLE
Throttle admin auth and bound rate-limit map

### DIFF
--- a/backend/admin.js
+++ b/backend/admin.js
@@ -15,11 +15,32 @@ function safeEqual(a, b) {
   return timingSafeEqual(ha, hb);
 }
 
+// Per-IP admin auth throttle: lock out an IP after too many failures.
+const AUTH_FAILS = new Map(); // ip -> { count, firstAt, lockedUntil }
+const MAX_FAILS = 5;
+const LOCK_MS = 10 * 60 * 1000;   // 10 min lockout
+const FAIL_WINDOW_MS = 10 * 60 * 1000;
+
+function adminIp(req) {
+  return req.headers['x-real-ip'] || req.ip || req.socket?.remoteAddress || 'unknown';
+}
+
 function basicAuth(req, res, next) {
   const password = process.env.ADMIN_PASSWORD;
   if (!password) return res.status(503).send('ADMIN_PASSWORD not set.');
 
+  const ip = adminIp(req);
+  const now = Date.now();
+  const rec = AUTH_FAILS.get(ip);
+  if (rec && rec.lockedUntil && now < rec.lockedUntil) {
+    res.set('Retry-After', String(Math.ceil((rec.lockedUntil - now) / 1000)));
+    return res.status(429).send('Too many attempts. Try again later.');
+  }
+
   const header = req.headers.authorization || '';
+  // A missing/non-Basic header is NOT a failed password — browsers send no auth
+  // on the first request. Do NOT count it toward lockout or the admin could be
+  // locked out of their own panel permanently.
   if (!header.startsWith('Basic ')) {
     res.set('WWW-Authenticate', 'Basic realm="term-site admin"');
     return res.status(401).send('Authentication required.');
@@ -34,9 +55,16 @@ function basicAuth(req, res, next) {
   // Constant-time comparison via HMAC digest (fixed 32-byte output regardless
   // of input length, so timingSafeEqual never throws on length mismatch)
   if (!safeEqual(user, email) || !safeEqual(pass, password)) {
+    const r = AUTH_FAILS.get(ip) || { count: 0, firstAt: now, lockedUntil: 0 };
+    if (now - r.firstAt > FAIL_WINDOW_MS) { r.count = 0; r.firstAt = now; }
+    r.count++;
+    if (r.count >= MAX_FAILS) r.lockedUntil = now + LOCK_MS;
+    AUTH_FAILS.set(ip, r);
     res.set('WWW-Authenticate', 'Basic realm="term-site admin"');
     return res.status(401).send('Invalid credentials.');
   }
+
+  AUTH_FAILS.delete(ip); // success clears the counter
   next();
 }
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -59,12 +59,20 @@ function checkRateLimit(ip) {
     connectionTracker.set(ip, []);
   }
   const timestamps = connectionTracker.get(ip).filter(t => now - t < RATE_LIMIT_WINDOW);
-  connectionTracker.set(ip, timestamps);
+  // Drop the key entirely when nothing is left in the window so the map can't
+  // accumulate a permanent empty-array entry per unique visitor IP.
+  if (timestamps.length === 0) {
+    connectionTracker.delete(ip);
+  } else {
+    connectionTracker.set(ip, timestamps);
+  }
 
   if (timestamps.length >= MAX_CONNECTIONS_PER_IP) {
+    connectionTracker.set(ip, timestamps); // keep the full window for lockout
     return false;
   }
   timestamps.push(now);
+  connectionTracker.set(ip, timestamps);
   return true;
 }
 
@@ -232,6 +240,16 @@ sessionManager.startPoolMaintenance();
 setInterval(() => {
   sessionManager.cleanupOrphanedContainers();
 }, 60 * 1000);
+
+// Drop stale per-IP rate-limit entries so the map can't grow unbounded.
+setInterval(() => {
+  const now = Date.now();
+  for (const [ip, ts] of connectionTracker) {
+    if (!ts.length || now - ts[ts.length - 1] > RATE_LIMIT_WINDOW) {
+      connectionTracker.delete(ip);
+    }
+  }
+}, 5 * 60 * 1000);
 
 // Start server
 const PORT = process.env.PORT || 3001;

--- a/backend/test-admin-auth.js
+++ b/backend/test-admin-auth.js
@@ -125,4 +125,61 @@ ok('basicAuth: no ADMIN_PASSWORD → 503', () => {
   process.env.ADMIN_PASSWORD = saved;
 });
 
+// ── per-IP brute-force throttle tests ─────────────────────────────────────────
+// Build a req carrying an x-real-ip header so the throttle keys per-IP and
+// distinct test IPs don't bleed lockout state into each other.
+function makeReqFromIp(authHeader, ip) {
+  return { headers: { authorization: authHeader || '', 'x-real-ip': ip } };
+}
+
+ok('basicAuth: 5 wrong passwords then 6th from same IP → 429 + Retry-After', () => {
+  const ip = '203.0.113.10';
+  const wrong = encode('admin@example.com', 'nope');
+  for (let i = 0; i < 5; i++) {
+    const res = makeRes();
+    basicAuth(makeReqFromIp(wrong, ip), res, () => {});
+    assert.strictEqual(res._statusCode, 401, `attempt ${i + 1} should be 401`);
+  }
+  const res = makeRes();
+  let nextCalled = false;
+  basicAuth(makeReqFromIp(wrong, ip), res, () => { nextCalled = true; });
+  assert.strictEqual(res._statusCode, 429, '6th attempt should be 429');
+  assert.ok(res.headers['Retry-After'], 'Retry-After header should be set');
+  assert.strictEqual(nextCalled, false);
+});
+
+ok('basicAuth: correct credentials reset the failure counter', () => {
+  const ip = '203.0.113.20';
+  const wrong = encode('admin@example.com', 'nope');
+  const right = encode('admin@example.com', 'correct-password');
+  for (let i = 0; i < 4; i++) {
+    basicAuth(makeReqFromIp(wrong, ip), makeRes(), () => {});
+  }
+  // Correct request clears the counter.
+  let nextCalled = false;
+  basicAuth(makeReqFromIp(right, ip), makeRes(), () => { nextCalled = true; });
+  assert.strictEqual(nextCalled, true, 'correct creds should call next()');
+  // 4 more wrong attempts: still under the limit because the counter reset.
+  for (let i = 0; i < 4; i++) {
+    const res = makeRes();
+    basicAuth(makeReqFromIp(wrong, ip), res, () => {});
+    assert.strictEqual(res._statusCode, 401, `post-reset attempt ${i + 1} should be 401, not 429`);
+  }
+});
+
+ok('basicAuth: missing Authorization header → 401 and does not count toward lockout', () => {
+  const ip = '203.0.113.30';
+  // Many no-auth requests (as a browser sends on first load) must never lock out.
+  for (let i = 0; i < 10; i++) {
+    const res = makeRes();
+    basicAuth(makeReqFromIp('', ip), res, () => {});
+    assert.strictEqual(res._statusCode, 401, `no-auth request ${i + 1} should be 401`);
+  }
+  // A subsequent wrong-password attempt still gets 401 (counter starts at 1),
+  // proving the no-auth requests were not counted.
+  const res = makeRes();
+  basicAuth(makeReqFromIp(encode('admin@example.com', 'nope'), ip), res, () => {});
+  assert.strictEqual(res._statusCode, 401, 'first real failure should be 401, not 429');
+});
+
 console.log(`\n${passed} tests passed.`);


### PR DESCRIPTION
## What

Implements **plan 004** (`plans/004-admin-throttle-and-bound-maps.md`): per-IP brute-force throttle on admin basic-auth, and bounds the per-IP connection-tracking map.

## Why

- The admin endpoint's only brute-force guard was nginx's global 10 r/s limit — ~600 password guesses/min against `ADMIN_PASSWORD`, indefinitely.
- `connectionTracker` left a permanent empty-array entry per unique visitor IP — a slow memory leak on a long-running backend.

## Changes (`backend/`)

- **`admin.js`** — in-process per-IP throttle (no new deps): 5 failed attempts within 10 min → 429 + `Retry-After` for 10 min. Lockout-safety guarantees: a **missing auth header returns 401 and never counts** (browsers always send no auth first — counting it would lock the admin out of their own panel), and **successful auth clears the counter**. The timing-safe HMAC comparison is untouched.
- **`server.js`** — `checkRateLimit` deletes empty-window keys; a 5-min sweep drops stale entries so the map stays bounded.
- **`test-admin-auth.js`** — 3 new cases: 6th wrong attempt → 429 + `Retry-After`; correct creds reset the counter; no-auth-header → 401 and not counted. 17/17 pass.

## Verification

- `node --check` clean on both files; `cd backend && npm test` → 17/17
- Adversarial lockout-safety review verified empirically (mocked clock) that lockout expires after 10 min and a legit admin can always recover.

### Follow-up (noted, not in this PR)
The rolling fail-window means an attacker pacing guesses >5 min apart avoids lockout (accepted simple design; nginx rate-limit + strong password bound that case). A fixed-window or sliding-count is a cheap future tighten.

Produced via isolated-worktree workflow: implement → 3-lens adversarial review (lockout-safety, scope, done-criteria) → independent re-verify; diff reviewed and tests re-run by hand before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
