### PR TITLE
Rotate audit log at size bound

### DIFF
--- a/backend/logger.js
+++ b/backend/logger.js
@@ -2,23 +2,40 @@ const fs = require('fs');
 const path = require('path');
 
 const LOG_FILE = process.env.LOG_FILE || path.join(__dirname, 'data', 'events.jsonl');
+const MAX_BYTES = Number(process.env.LOG_MAX_BYTES || 5 * 1024 * 1024); // 5 MB
+
+function rotateIfNeeded() {
+  try {
+    const { size } = fs.statSync(LOG_FILE);
+    if (size < MAX_BYTES) return;
+    // Single-backup rotation: events.jsonl -> events.jsonl.1 (overwrite).
+    fs.renameSync(LOG_FILE, LOG_FILE + '.1');
+  } catch (err) {
+    if (err.code !== 'ENOENT') console.error('Log rotate error:', err.message);
+  }
+}
 
 function append(event) {
   try {
     fs.mkdirSync(path.dirname(LOG_FILE), { recursive: true });
+    rotateIfNeeded();
     fs.appendFileSync(LOG_FILE, JSON.stringify({ ...event, at: Date.now() }) + '\n');
   } catch (err) {
     console.error('Logger error:', err.message);
   }
 }
 
-function readAll() {
+function readOne(file) {
   try {
-    return fs.readFileSync(LOG_FILE, 'utf-8')
+    return fs.readFileSync(file, 'utf-8')
       .trim().split('\n').filter(Boolean)
       .map(line => { try { return JSON.parse(line); } catch { return null; } })
       .filter(Boolean);
   } catch { return []; }
+}
+
+function readAll() {
+  return [...readOne(LOG_FILE + '.1'), ...readOne(LOG_FILE)];
 }
 
 module.exports = { append, readAll };

--- a/backend/test-logger-rotation.js
+++ b/backend/test-logger-rotation.js
@@ -1,0 +1,80 @@
+'use strict';
+// Minimal regression tests for logger rotation — no test framework required.
+// Run: node backend/test-logger-rotation.js
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+let passed = 0;
+function ok(label, fn) {
+  try {
+    fn();
+    console.log(`  ok  ${label}`);
+    passed++;
+  } catch (e) {
+    console.error(`FAIL  ${label}`);
+    console.error('      ' + e.message);
+    process.exitCode = 1;
+  }
+}
+
+// Isolate via env: the logger module caches LOG_FILE / LOG_MAX_BYTES at
+// require time, so set both BEFORE require('./logger').
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'logger-rotation-test-'));
+const LOG_FILE = path.join(tmpDir, 'events.jsonl');
+const MAX_BYTES = 1024;
+process.env.LOG_FILE = LOG_FILE;
+process.env.LOG_MAX_BYTES = String(MAX_BYTES);
+
+const { append, readAll } = require('./logger');
+
+// ── rotation tests ────────────────────────────────────────────────────────────
+// Two-file rotation only guarantees no event loss across a SINGLE rotation
+// (a second rotation overwrites the .1 backup by design), so append until the
+// first rotation happens, then a few more — and stop well before a second one.
+let TOTAL = 0;
+while (!fs.existsSync(LOG_FILE + '.1') && TOTAL < 100) {
+  append({ type: 'command', seq: TOTAL, pad: 'x'.repeat(100) });
+  TOTAL++;
+}
+for (let i = 0; i < 3; i++) {
+  append({ type: 'command', seq: TOTAL, pad: 'x'.repeat(100) });
+  TOTAL++;
+}
+
+ok('rotation: events.jsonl.1 exists after exceeding LOG_MAX_BYTES', () =>
+  assert.ok(fs.existsSync(LOG_FILE + '.1'), 'expected rotated backup file'));
+
+ok('rotation: current events.jsonl is smaller than LOG_MAX_BYTES', () =>
+  assert.ok(fs.statSync(LOG_FILE).size < MAX_BYTES,
+    `current file is ${fs.statSync(LOG_FILE).size} bytes, expected < ${MAX_BYTES}`));
+
+// ── readAll continuity tests ──────────────────────────────────────────────────
+const events = readAll();
+
+ok('readAll: returns events from both files (no events lost to rotation)', () =>
+  assert.strictEqual(events.length, TOTAL,
+    `expected ${TOTAL} events, got ${events.length}`));
+
+ok('readAll: events are in append order (earliest first, latest last)', () => {
+  assert.strictEqual(events[0].seq, 0, 'first event should be seq 0');
+  assert.strictEqual(events[events.length - 1].seq, TOTAL - 1,
+    `last event should be seq ${TOTAL - 1}`);
+  for (let i = 0; i < events.length; i++) {
+    assert.strictEqual(events[i].seq, i, `event at index ${i} should be seq ${i}`);
+  }
+});
+
+ok('readAll: every event is an object with the appended fields plus "at"', () => {
+  for (const e of events) {
+    assert.strictEqual(typeof e, 'object');
+    assert.strictEqual(e.type, 'command');
+    assert.strictEqual(typeof e.at, 'number');
+  }
+});
+
+// ── cleanup ───────────────────────────────────────────────────────────────────
+fs.rmSync(tmpDir, { recursive: true, force: true });
+
+console.log(`\n${passed} tests passed.`);


### PR DESCRIPTION
## What

Implements **plan 006** (`plans/006-rotate-audit-log.md`): size-bounded two-file rotation for the backend audit log, so it can no longer grow unbounded.

## Why

`events.jsonl` (visitor IPs + commands) grew forever with no rotation, and `readAll()` parses the whole file into memory on **every** admin page load — O(total history) per request, plus an unbounded plaintext-IP retention window.

## Changes (`backend/`)

- **`logger.js`** — `rotateIfNeeded()` renames `events.jsonl → events.jsonl.1` (overwriting) when it reaches `LOG_MAX_BYTES` (env, default 5 MB), called **before** the append so the in-flight event always lands in the fresh file. `readAll()` now returns `[.1 events..., current events...]` — same shape and order, so `admin.js` needed (and received) **zero changes**. Total disk and admin-read cost bounded at ~2× the limit.
- **`test-logger-rotation.js`** (new) — temp-dir test: rotation fires at the bound, current file stays under it, `readAll` merges both files in append order with no event lost across a rotation. 5/5 pass; admin-auth suite still 17/17.

### Notes
- A misconfigured non-numeric `LOG_MAX_BYTES` would make `MAX_BYTES` NaN and rotate every append (no crash, no contract break) — env-misconfig edge only, noted for completeness.
- IP anonymization/retention policy deliberately deferred (product decision); rotation bounds retention to the recent window.

Produced via isolated-worktree workflow: implement → 3-lens adversarial review (data-safety incl. event-loss probes, scope, done-criteria) → independent re-verify; diff and tests re-run by hand before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
