### PR TITLE
Filter dangerous URL schemes in terminal links

### DIFF
--- a/frontend/src/components/BlogUnifiedPage.tsx
+++ b/frontend/src/components/BlogUnifiedPage.tsx
@@ -12,6 +12,7 @@ import {
   CODE_BORDER,
 } from '@/lib/markdown-components';
 import { terminalConfig, terminalTheme } from '@/config/terminal-theme';
+import { isSafeExternalUrl } from '@/lib/safe-url';
 
 function hexToAnsiRgb(hex: string): string {
   const n = parseInt(hex.replace('#', ''), 16);
@@ -88,8 +89,10 @@ export default function BlogUnifiedPage({ slug, title, date, body }: Props) {
         disableStdin: false,
       });
 
-      const openLink = (_e: MouseEvent, href: string) =>
+      const openLink = (_e: MouseEvent, href: string) => {
+        if (!isSafeExternalUrl(href)) return;
         window.open(href, '_blank', 'noopener,noreferrer');
+      };
       xterm.loadAddon(new WebLinksAddon(openLink));
       xterm.options.linkHandler = { activate: openLink, allowNonHttpProtocols: true };
 

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -18,6 +18,7 @@ import {
   type TerminalDimensions,
 } from "../lib/mobile-viewport";
 import { attachTouchScroll } from "../lib/xterm-touch";
+import { isSafeExternalUrl } from "../lib/safe-url";
 
 const MOBILE_BREAKPOINT = 768;
 const MIN_FONT_SIZE = 10;
@@ -90,6 +91,7 @@ const Terminal = forwardRef<TerminalRef, TerminalProps>(
       xterm.loadAddon(fitAddon);
 
       const handleLinkActivate = (_event: MouseEvent, text: string) => {
+        if (!isSafeExternalUrl(text)) return;
         window.open(text, "_blank", "noopener,noreferrer");
       };
       xterm.options.linkHandler = {

--- a/frontend/src/lib/__tests__/safe-url.test.ts
+++ b/frontend/src/lib/__tests__/safe-url.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { isSafeExternalUrl } from '../safe-url';
+
+describe('isSafeExternalUrl', () => {
+  it('https://example.com → true', () => expect(isSafeExternalUrl('https://example.com')).toBe(true));
+  it('http://example.com/path?q=1 → true', () => expect(isSafeExternalUrl('http://example.com/path?q=1')).toBe(true));
+  it('mailto:a@b.com → true', () => expect(isSafeExternalUrl('mailto:a@b.com')).toBe(true));
+  it('javascript:alert(1) → false', () => expect(isSafeExternalUrl('javascript:alert(1)')).toBe(false));
+  it('JavaScript:alert(1) (case-variant) → false', () => expect(isSafeExternalUrl('JavaScript:alert(1)')).toBe(false));
+  it('data:text/html,<script> → false', () => expect(isSafeExternalUrl('data:text/html,<script>')).toBe(false));
+  it('vbscript:msgbox → false', () => expect(isSafeExternalUrl('vbscript:msgbox')).toBe(false));
+  it('//evil.com (protocol-relative) → false', () => expect(isSafeExternalUrl('//evil.com')).toBe(false));
+  it('not a url → false', () => expect(isSafeExternalUrl('not a url')).toBe(false));
+  it('empty string → false', () => expect(isSafeExternalUrl('')).toBe(false));
+});

--- a/frontend/src/lib/safe-url.ts
+++ b/frontend/src/lib/safe-url.ts
@@ -1,0 +1,14 @@
+// Allow only schemes safe to hand to window.open from terminal/markdown
+// output. Blocks javascript:, data:, vbscript:, blob:, file:, etc.
+const SAFE_SCHEMES = new Set(["http:", "https:", "mailto:"]);
+
+export function isSafeExternalUrl(text: string): boolean {
+  if (typeof text !== "string" || text.length === 0) return false;
+  let url: URL;
+  try {
+    url = new URL(text);
+  } catch {
+    return false; // not an absolute URL with a parseable scheme → don't open
+  }
+  return SAFE_SCHEMES.has(url.protocol);
+}


### PR DESCRIPTION
## What

Implements **plan 007** (`plans/007-filter-dangerous-link-schemes.md`): a URL-scheme allowlist (`http:`/`https:`/`mailto:`) before any terminal- or markdown-derived link opens via `window.open`.

## Why

xterm's link handler runs with `allowNonHttpProtocols: true` and opened whatever text it was given — a clicked `javascript:`/`data:` link executes script. Self-XSS only in the current threat model (visitors only see their own container's output), but the guard is 14 lines of defense-in-depth that becomes load-bearing if output is ever shared.

## Changes (`frontend/`)

- **`src/lib/safe-url.ts`** (new) — `isSafeExternalUrl()`: parse with `new URL()`, allowlist the protocol. `mailto:` allowlisted because the contact script emits it.
- **`src/components/Terminal.tsx`** — early-return gate in `handleLinkActivate` (covers both `linkHandler` and the WebLinksAddon, which share the callback). OSC 9999/9998/9997 handlers and `allowNonHttpProtocols` untouched.
- **`src/components/BlogUnifiedPage.tsx`** — same gate on its `openLink`.
- **`src/lib/__tests__/safe-url.test.ts`** (new) — 10 cases (https/http/mailto pass; javascript/JavaScript/data/vbscript/protocol-relative/garbage/empty rejected).

## Verification

- Adversarial bypass hunt: mixed case, leading whitespace/control chars, tab/newline **inside** the scheme (`java\tscript:`), `%6a`-encoded schemes, `blob:`/`file:` — all blocked (`new URL()` normalization + protocol check).
- Call-site sweep: every `window.open` of content-derived text is gated; both `location.assign` sites are same-origin-only and unchanged.
- `tsc --noEmit` clean, 60/60 tests, lint clean, build green; no `as any` casts.

Produced via isolated-worktree workflow: implement → 3-lens adversarial review (bypass-hunt, scope, done-criteria) → independent re-verify; diff and tests re-run by hand before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
